### PR TITLE
add isInsufficientMaterial and game tags

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -48,6 +48,7 @@ export class Game {
 	private _date?: DateValue;
 	private _site?: string;
 	private _annotator?: string;
+	private _tags: Record<string, string>;
 	private _result: number;
 
 	// Moves
@@ -58,6 +59,7 @@ export class Game {
 		this._playerName = [ undefined, undefined ];
 		this._playerElo = [ undefined, undefined ];
 		this._playerTitle = [ undefined, undefined ];
+		this._tags = {};
 		this._result = GameResultImpl.LINE;
 		this._moveTreeRoot = new MoveTreeRoot();
 	}
@@ -86,6 +88,24 @@ export class Game {
 		else {
 			this._playerName[colorCode] = sanitizeStringHeader(value);
 		}
+	}
+
+	/**
+   * Get or Set custom game tag
+   */
+	tag(tagName: string, value?: string): string | undefined {
+		if (value) {
+			this._tags[tagName] = String(value);
+		}
+		return this._tags?.[tagName];
+	}
+
+
+	/**
+   * Get all custom game tags
+   */
+	tags(): Record<string, string> {
+		return this._tags;
 	}
 
 

--- a/src/position.ts
+++ b/src/position.ts
@@ -32,7 +32,7 @@ import { ascii, getFEN, parseFEN } from './private_position/fen';
 import { PositionImpl, makeCopy, makeEmpty, makeInitial, make960FromScharnagl, hasCanonicalStartPosition } from './private_position/impl';
 import { isLegal, refreshLegalFlagAndKingSquares, refreshEffectiveEnPassant, isEqual, refreshEffectiveCastling } from './private_position/legality';
 import { MoveDescriptorImpl } from './private_position/move_descriptor_impl';
-import { isCheck, isCheckmate, isStalemate, hasMove, moves, isMoveLegal, play, isNullMoveLegal, playNullMove } from './private_position/move_generation';
+import { isCheck, isCheckmate, isStalemate, isInsufficientMaterial, hasMove, moves, isMoveLegal, play, isNullMoveLegal, playNullMove } from './private_position/move_generation';
 import { getNotation, parseNotation } from './private_position/notation';
 import { getUCINotation, parseUCINotation } from './private_position/uci';
 
@@ -660,6 +660,16 @@ export class Position {
 	 */
 	isStalemate(): boolean {
 		return isStalemate(this._impl);
+	}
+
+	/**
+	 * Whether both players have insufficient material so the game cannot end in checkmate. If the position is not legal (see {@link Position.isLegal}),
+	 * the returned value is always `false`.
+	 *
+	 * For antichess and horde chess, this method always returns `false`
+	 */
+	isInsufficientMaterial(): boolean {
+		return isInsufficientMaterial(this._impl);
 	}
 
 

--- a/src/position.ts
+++ b/src/position.ts
@@ -665,11 +665,14 @@ export class Position {
 	/**
 	 * Whether both players have insufficient material so the game cannot end in checkmate. If the position is not legal (see {@link Position.isLegal}),
 	 * the returned value is always `false`.
+   *
+   * If `forcedMate` is not set or set to `false`, method uses **FIDE** rules where position is evaluated to return no possible checkmates
+   * If `forcedMate` is set to `true`, method uses **USCF** rules where position is evaluated to return no possible *forced* checkmates
 	 *
 	 * For antichess and horde chess, this method always returns `false`
 	 */
-	isInsufficientMaterial(): boolean {
-		return isInsufficientMaterial(this._impl);
+	isInsufficientMaterial(forcedMate?: boolean): boolean {
+		return isInsufficientMaterial(this._impl, forcedMate);
 	}
 
 

--- a/src/private_pgn/pgn_write_impl.ts
+++ b/src/private_pgn/pgn_write_impl.ts
@@ -229,6 +229,9 @@ export function writeGame(game: Game) {
 	result += writeOptionalHeader('Variant', formatVariant(variant));
 	result += writeOptionalIntegerHeader('WhiteElo', game.playerElo('w'));
 	result += writeOptionalHeader('WhiteTitle', game.playerTitle('w'));
+	for (const [tag, value] of Object.entries(game.tags())) {
+		result += writeOptionalHeader(tag, value);
+	}
 
 	// Separator
 	result += '\n';

--- a/src/private_position/move_generation.ts
+++ b/src/private_position/move_generation.ts
@@ -144,6 +144,31 @@ export function isStalemate(position: PositionImpl) {
 
 
 /**
+ * Whether the given position is level and there is insufficient material on board.
+ */
+export function isInsufficientMaterial(position: PositionImpl) {
+	if (!isLegal(position) || hasMove(position)) {
+		return false;
+	}
+	if (position.variant === GameVariantImpl.ANTICHESS) {
+		return false;
+	}
+	else if (position.variant === GameVariantImpl.HORDE && position.turn === ColorImpl.WHITE) {
+		return false;
+	}
+	else {
+		const FEN_PIECE_SYMBOL = [ ...'KkQqRrBbNnPp' ];
+		const board: string[] = position.board.map((piece) => FEN_PIECE_SYMBOL[piece]);
+		const pieces: string = board.filter((piece) => piece).join(''); // string with all pieces on the board
+		const sides: [string, string] = [pieces.replace(/[a-z]/g, '').toLowerCase(), pieces.replace(/[A-Z]/g, '')]; // split per side
+		const noKings = sides.map((side) => side.replace('k', '')) as [string, string]; // dont look at kings
+		const insufficient = noKings.map((side) => side.length === 0 || side.length === 1 && (side[0][0] === 'n' || side[0][0] === 'b')) as [boolean, boolean]; // no pieces or just knight or just bishop
+		return insufficient[0] && insufficient[1]; // both sides have insufficient material
+	}
+}
+
+
+/**
  * Whether there is at least 1 possible move in the given position.
  *
  * @returns `false` if the position is not legal.


### PR DESCRIPTION
add new method `position.isInsufficientMaterial()`  
simple definition is if both sides have either just kings or king+knight or king+bishop on the board  
as those positions cannot result in a checkmate.

add new optinal `game.tag` record which allows setting custom game tags which are then written to pgn when using `pgnWrite`

example usage for both:
```js
    if (position.isStalemate()) {
      game.tag('Termination', 'stalemate');
      game.result('1/2-1/2');
    }
    if (position.isInsufficientMaterial()) {
      game.tag('Termination', 'insufficient material');
      game.result('1/2-1/2');
    }
```
