### PR TITLE
add isInsufficientMaterial method

### DIFF
--- a/src/position.ts
+++ b/src/position.ts
@@ -32,7 +32,7 @@ import { ascii, getFEN, parseFEN } from './private_position/fen';
 import { PositionImpl, makeCopy, makeEmpty, makeInitial, make960FromScharnagl, hasCanonicalStartPosition } from './private_position/impl';
 import { isLegal, refreshLegalFlagAndKingSquares, refreshEffectiveEnPassant, isEqual, refreshEffectiveCastling } from './private_position/legality';
 import { MoveDescriptorImpl } from './private_position/move_descriptor_impl';
-import { isCheck, isCheckmate, isStalemate, isInsufficientMaterial, hasMove, moves, isMoveLegal, play, isNullMoveLegal, playNullMove } from './private_position/move_generation';
+import { isCheck, isCheckmate, isStalemate, isDead, hasMove, moves, isMoveLegal, play, isNullMoveLegal, playNullMove } from './private_position/move_generation';
 import { getNotation, parseNotation } from './private_position/notation';
 import { getUCINotation, parseUCINotation } from './private_position/uci';
 
@@ -672,8 +672,8 @@ export class Position {
 	 *
 	 * For antichess and horde chess, this method always returns `false`
 	 */
-	isInsufficientMaterial(forcedMate?: boolean): boolean {
-		return isInsufficientMaterial(this._impl, forcedMate);
+	isDead(forcedMate?: boolean): boolean {
+		return isDead(this._impl, forcedMate);
 	}
 
 

--- a/src/position.ts
+++ b/src/position.ts
@@ -32,7 +32,7 @@ import { ascii, getFEN, parseFEN } from './private_position/fen';
 import { PositionImpl, makeCopy, makeEmpty, makeInitial, make960FromScharnagl, hasCanonicalStartPosition } from './private_position/impl';
 import { isLegal, refreshLegalFlagAndKingSquares, refreshEffectiveEnPassant, isEqual, refreshEffectiveCastling } from './private_position/legality';
 import { MoveDescriptorImpl } from './private_position/move_descriptor_impl';
-import { isCheck, isCheckmate, isStalemate, hasMove, moves, isMoveLegal, play, isNullMoveLegal, playNullMove } from './private_position/move_generation';
+import { isCheck, isCheckmate, isStalemate, isInsufficientMaterial, hasMove, moves, isMoveLegal, play, isNullMoveLegal, playNullMove } from './private_position/move_generation';
 import { getNotation, parseNotation } from './private_position/notation';
 import { getUCINotation, parseUCINotation } from './private_position/uci';
 
@@ -660,6 +660,20 @@ export class Position {
 	 */
 	isStalemate(): boolean {
 		return isStalemate(this._impl);
+	}
+
+
+	/**
+	 * Whether both players have insufficient material so the game cannot end in checkmate. If the position is not legal (see {@link Position.isLegal}),
+	 * the returned value is always `false`.
+   *
+   * If `forcedMate` is not set or set to `false`, method uses **FIDE** rules where position is evaluated to return no possible checkmates
+   * If `forcedMate` is set to `true`, method uses **USCF** rules where position is evaluated to return no possible *forced* checkmates
+	 *
+	 * For antichess and horde chess, this method always returns `false`
+	 */
+	isInsufficientMaterial(forcedMate?: boolean): boolean {
+		return isInsufficientMaterial(this._impl, forcedMate);
 	}
 
 

--- a/src/private_position/move_generation.ts
+++ b/src/private_position/move_generation.ts
@@ -147,7 +147,7 @@ export function isStalemate(position: PositionImpl) {
  * Whether the given position is level and there is insufficient material on board.
  */
 export function isDead(position: PositionImpl, forcedMate?: boolean) {
-	if (!isLegal(position) || hasMove(position)) {
+	if (!isLegal(position) || !hasMove(position)) {
 		return false;
 	}
 	if (position.variant === GameVariantImpl.ANTICHESS) {

--- a/src/private_position/move_generation.ts
+++ b/src/private_position/move_generation.ts
@@ -146,16 +146,19 @@ export function isStalemate(position: PositionImpl) {
 /**
  * Whether the given position is level and there is insufficient material on board.
  */
-export function isInsufficientMaterial(position: PositionImpl, forcedMate?: boolean) {
+export function isDead(position: PositionImpl, forcedMate?: boolean) {
+	if (!isLegal(position) || hasMove(position)) {
+		return false;
+	}
 	if (position.variant === GameVariantImpl.ANTICHESS) {
 		return false;
 	}
-	else if (position.variant === GameVariantImpl.HORDE && position.turn === ColorImpl.WHITE) {
+	else if (position.variant === GameVariantImpl.HORDE) {
 		return false;
 	}
 	else {
 		const FEN_PIECE_SYMBOL = [ ...'KkQqRrBbNnPp' ];
-		const DEF_INSUFFICIENT_FIDE = ['kk', 'kkn', 'kbk', 'knkn']; // no possible mate
+		const DEF_INSUFFICIENT_FIDE = ['kk', 'kkn', 'kbk']; // no possible mate
 		const DEF_INSUFFICIENT_USCF = ['bkbk', 'bkkn']; // no possible forced mate
 		const board: string[] = position.board.map((piece) => FEN_PIECE_SYMBOL[piece]); // board with all pieces
 		const [w, b] = [

--- a/src/private_position/move_generation.ts
+++ b/src/private_position/move_generation.ts
@@ -144,6 +144,36 @@ export function isStalemate(position: PositionImpl) {
 
 
 /**
+ * Whether the given position is level and there is insufficient material on board.
+ */
+export function isInsufficientMaterial(position: PositionImpl, forcedMate?: boolean) {
+	if (position.variant === GameVariantImpl.ANTICHESS) {
+		return false;
+	}
+	else if (position.variant === GameVariantImpl.HORDE && position.turn === ColorImpl.WHITE) {
+		return false;
+	}
+	else {
+		const FEN_PIECE_SYMBOL = [ ...'KkQqRrBbNnPp' ];
+		const DEF_INSUFFICIENT_FIDE = ['kk', 'kkn', 'kbk', 'knkn']; // no possible mate
+		const DEF_INSUFFICIENT_USCF = ['bkbk', 'bkkn']; // no possible forced mate
+		const board: string[] = position.board.map((piece) => FEN_PIECE_SYMBOL[piece]); // board with all pieces
+		const [w, b] = [
+			board.filter((piece) => piece && piece.match('[A-Z]')).sort((s0, s1) => (s0 > s1 ? 1 : -1)).join('').toLowerCase(), // string with all white pieces on the board sorted alphabetically
+			board.filter((piece) => piece && piece.match('[a-z]')).sort((s0, s1) => (s0 > s1 ? 1 : -1)).join(''), // string with all black pieces on the board sorted alphabetically
+		];
+		if (DEF_INSUFFICIENT_FIDE.includes(w + b) || DEF_INSUFFICIENT_FIDE.includes(b + w)) {
+			return true;
+		}
+		if (forcedMate && (DEF_INSUFFICIENT_USCF.includes(w + b) || DEF_INSUFFICIENT_USCF.includes(b + w))) {
+			return true;
+		}
+		return false;
+	}
+}
+
+
+/**
  * Whether there is at least 1 possible move in the given position.
  *
  * @returns `false` if the position is not legal.


### PR DESCRIPTION
adds method to detect insufficient material to end game in checkmate under both FIDE and USCF rules.  
further notes in previous version of the pr #34